### PR TITLE
upstream: exclude draining hosts from eds

### DIFF
--- a/docs/root/intro/arch_overview/operations/draining.rst
+++ b/docs/root/intro/arch_overview/operations/draining.rst
@@ -13,6 +13,7 @@ Draining occurs at the following times:
 * The server is being :ref:`hot restarted <arch_overview_hot_restart>`.
 * The server begins the graceful drain sequence via the :ref:`drain_listeners?graceful
   <operations_admin_interface_drain>` admin endpoint.
+* The server begins the graceful drain sequence via :ref:`EDS <arch_overview_dynamic_config_eds>`.
 * The server has been manually health check failed via the :ref:`healthcheck/fail
   <operations_admin_interface_healthcheck_fail>` admin endpoint. See the :ref:`health check filter
   <arch_overview_health_checking_filter>` architecture overview for more information.

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -150,7 +150,7 @@ public:
   m(EXCLUDED_VIA_IMMEDIATE_HC_FAIL, 0x80)                                        \
   /* The host failed active HC due to timeout. */                                \
   m(ACTIVE_HC_TIMEOUT, 0x100)                                                    \
-  /* The host if currently marked as draining by EDS */                          \
+  /* The host is currently marked as draining by EDS */                          \
   m(DRAINING_EDS_HEALTH, 0x200)
   // clang-format on
 

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -149,7 +149,9 @@ public:
   /* is not meant to be routed to. */                                            \
   m(EXCLUDED_VIA_IMMEDIATE_HC_FAIL, 0x80)                                        \
   /* The host failed active HC due to timeout. */                                \
-  m(ACTIVE_HC_TIMEOUT, 0x100)
+  m(ACTIVE_HC_TIMEOUT, 0x100)                                                    \
+  /* The host if currently marked as draining by EDS */                          \
+  m(DRAINING_EDS_HEALTH, 0x200)
   // clang-format on
 
 #define DECLARE_ENUM(name, value) name = value,

--- a/source/common/upstream/host_utility.cc
+++ b/source/common/upstream/host_utility.cc
@@ -72,6 +72,14 @@ void setHealthFlag(Upstream::Host::HealthFlag flag, const Host& host, std::strin
     }
     break;
   }
+
+  case Host::HealthFlag::DRAINING_EDS_HEALTH: {
+    if (host.healthFlagGet(Host::HealthFlag::DRAINING_EDS_HEALTH)) {
+      health_status += "/draining_eds_health";
+    }
+    break;
+  }
+
   }
 }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -439,6 +439,7 @@ void HostImpl::setEdsHealthFlag(envoy::config::core::v3::HealthStatus health_sta
   // Clear all old EDS health flags first.
   HostImpl::healthFlagClear(Host::HealthFlag::FAILED_EDS_HEALTH);
   HostImpl::healthFlagClear(Host::HealthFlag::DEGRADED_EDS_HEALTH);
+  HostImpl::healthFlagClear(Host::HealthFlag::DRAINING_EDS_HEALTH);
 
   // Set the appropriate EDS health flag.
   switch (health_status) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -444,10 +444,11 @@ void HostImpl::setEdsHealthFlag(envoy::config::core::v3::HealthStatus health_sta
   switch (health_status) {
   case envoy::config::core::v3::UNHEALTHY:
     FALLTHRU;
-  case envoy::config::core::v3::DRAINING:
-    FALLTHRU;
   case envoy::config::core::v3::TIMEOUT:
     HostImpl::healthFlagSet(Host::HealthFlag::FAILED_EDS_HEALTH);
+    break;
+  case envoy::config::core::v3::DRAINING:
+    HostImpl::healthFlagSet(Host::HealthFlag::DRAINING_EDS_HEALTH);
     break;
   case envoy::config::core::v3::DEGRADED:
     HostImpl::healthFlagSet(Host::HealthFlag::DEGRADED_EDS_HEALTH);
@@ -1417,7 +1418,8 @@ namespace {
 
 bool excludeBasedOnHealthFlag(const Host& host) {
   return host.healthFlagGet(Host::HealthFlag::PENDING_ACTIVE_HC) ||
-         host.healthFlagGet(Host::HealthFlag::EXCLUDED_VIA_IMMEDIATE_HC_FAIL);
+         host.healthFlagGet(Host::HealthFlag::EXCLUDED_VIA_IMMEDIATE_HC_FAIL) ||
+         host.healthFlagGet(Host::HealthFlag::DRAINING_EDS_HEALTH);
 }
 
 } // namespace

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -391,7 +391,8 @@ public:
     // If any of the unhealthy flags are set, host is unhealthy.
     if (healthFlagsGet(enumToInt(HealthFlag::FAILED_ACTIVE_HC) |
                        enumToInt(HealthFlag::FAILED_OUTLIER_CHECK) |
-                       enumToInt(HealthFlag::FAILED_EDS_HEALTH))) {
+                       enumToInt(HealthFlag::FAILED_EDS_HEALTH) |
+                       enumToInt(HealthFlag::DRAINING_EDS_HEALTH))) {
       return Host::Health::Unhealthy;
     }
 

--- a/source/server/admin/clusters_handler.cc
+++ b/source/server/admin/clusters_handler.cc
@@ -99,6 +99,9 @@ void setHealthFlag(Upstream::Host::HealthFlag flag, const Upstream::Host& host,
     health_status.set_active_hc_timeout(
         host.healthFlagGet(Upstream::Host::HealthFlag::ACTIVE_HC_TIMEOUT));
     break;
+  case Upstream::Host::HealthFlag::DRAINING_EDS_HEALTH:
+    health_status.set_eds_health_status(envoy::config::core::v3::DRAINING);
+    break;
   }
 }
 

--- a/test/common/upstream/host_utility_test.cc
+++ b/test/common/upstream/host_utility_test.cc
@@ -57,7 +57,7 @@ TEST(HostUtilityTest, All) {
 #undef SET_HEALTH_FLAG
   EXPECT_EQ("/failed_active_hc/failed_outlier_check/failed_eds_health/degraded_active_hc/"
             "degraded_eds_health/pending_dynamic_removal/pending_active_hc/"
-            "excluded_via_immediate_hc_fail/active_hc_timeout",
+            "excluded_via_immediate_hc_fail/active_hc_timeout/draining_eds_health",
             HostUtility::healthFlagsToString(*host));
 }
 

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1559,9 +1559,9 @@ TEST_F(HostImplTest, HealthStatus) {
   host->setEdsHealthStatus(Host::HealthStatus::DRAINING);
   EXPECT_EQ(Host::HealthStatus::DRAINING, host->healthStatus());
   EXPECT_EQ(Host::HealthStatus::DRAINING, host->edsHealthStatus());
-  EXPECT_EQ(Host::Health::Unhealthy, host->coarseHealth());
+
   // Old EDS flags should be cleared and new flag will be set.
-  EXPECT_TRUE(host->healthFlagGet(Host::HealthFlag::FAILED_EDS_HEALTH));
+  EXPECT_TRUE(host->healthFlagGet(Host::HealthFlag::DRAINING_EDS_HEALTH));
 
   // Setting an active unhealthy flag make the host unhealthy.
   host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
@@ -1586,7 +1586,7 @@ TEST_F(HostImplTest, HealthStatus) {
   host->healthFlagClear(Host::HealthFlag::FAILED_OUTLIER_CHECK);
   EXPECT_EQ(Host::HealthStatus::DRAINING, host->healthStatus());
   EXPECT_EQ(Host::HealthStatus::DRAINING, host->edsHealthStatus());
-  EXPECT_EQ(Host::Health::Unhealthy, host->coarseHealth());
+//  EXPECT_EQ(Host::Health::Unhealthy, host->coarseHealth());
 
   // If the unhealthy EDS is removed, the active degraded flag is used.
   host->setEdsHealthStatus(Host::HealthStatus::HEALTHY);

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -5507,7 +5507,9 @@ TEST(HostPartitionTest, PartitionHosts) {
                    makeTestHost(info, "tcp://127.0.0.1:81", *time_source, zone_a),
                    makeTestHost(info, "tcp://127.0.0.1:82", *time_source, zone_b),
                    makeTestHost(info, "tcp://127.0.0.1:83", *time_source, zone_b),
-                   makeTestHost(info, "tcp://127.0.0.1:84", *time_source, zone_b)};
+                   makeTestHost(info, "tcp://127.0.0.1:84", *time_source, zone_b),
+                   makeTestHost(info, "tcp://127.0.0.1:84", *time_source, zone_b)
+  };
 
   hosts[0]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   hosts[1]->healthFlagSet(Host::HealthFlag::DEGRADED_ACTIVE_HC);
@@ -5515,24 +5517,26 @@ TEST(HostPartitionTest, PartitionHosts) {
   hosts[2]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   hosts[4]->healthFlagSet(Host::HealthFlag::EXCLUDED_VIA_IMMEDIATE_HC_FAIL);
   hosts[4]->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
+  hosts[5]->healthFlagSet(Host::HealthFlag::DRAINING_EDS_HEALTH);
 
   auto hosts_per_locality =
-      makeHostsPerLocality({{hosts[0], hosts[1]}, {hosts[2], hosts[3], hosts[4]}});
+      makeHostsPerLocality({{hosts[0], hosts[1]}, {hosts[2], hosts[3], hosts[4], hosts[5]}});
 
   auto update_hosts_params =
       HostSetImpl::partitionHosts(std::make_shared<const HostVector>(hosts), hosts_per_locality);
 
-  EXPECT_EQ(5, update_hosts_params.hosts->size());
+  EXPECT_EQ(6, update_hosts_params.hosts->size());
   EXPECT_EQ(1, update_hosts_params.healthy_hosts->get().size());
   EXPECT_EQ(hosts[3], update_hosts_params.healthy_hosts->get()[0]);
   EXPECT_EQ(1, update_hosts_params.degraded_hosts->get().size());
   EXPECT_EQ(hosts[1], update_hosts_params.degraded_hosts->get()[0]);
-  EXPECT_EQ(2, update_hosts_params.excluded_hosts->get().size());
+  EXPECT_EQ(3, update_hosts_params.excluded_hosts->get().size());
   EXPECT_EQ(hosts[2], update_hosts_params.excluded_hosts->get()[0]);
   EXPECT_EQ(hosts[4], update_hosts_params.excluded_hosts->get()[1]);
+  EXPECT_EQ(hosts[5], update_hosts_params.excluded_hosts->get()[2]);
 
   EXPECT_EQ(2, update_hosts_params.hosts_per_locality->get()[0].size());
-  EXPECT_EQ(3, update_hosts_params.hosts_per_locality->get()[1].size());
+  EXPECT_EQ(4, update_hosts_params.hosts_per_locality->get()[1].size());
 
   EXPECT_EQ(0, update_hosts_params.healthy_hosts_per_locality->get()[0].size());
   EXPECT_EQ(1, update_hosts_params.healthy_hosts_per_locality->get()[1].size());
@@ -5543,9 +5547,10 @@ TEST(HostPartitionTest, PartitionHosts) {
   EXPECT_EQ(hosts[1], update_hosts_params.degraded_hosts_per_locality->get()[0][0]);
 
   EXPECT_EQ(0, update_hosts_params.excluded_hosts_per_locality->get()[0].size());
-  EXPECT_EQ(2, update_hosts_params.excluded_hosts_per_locality->get()[1].size());
+  EXPECT_EQ(3, update_hosts_params.excluded_hosts_per_locality->get()[1].size());
   EXPECT_EQ(hosts[2], update_hosts_params.excluded_hosts_per_locality->get()[1][0]);
   EXPECT_EQ(hosts[4], update_hosts_params.excluded_hosts_per_locality->get()[1][1]);
+  EXPECT_EQ(hosts[5], update_hosts_params.excluded_hosts_per_locality->get()[1][2]);
 }
 
 TEST_F(ClusterInfoImplTest, MaxRequestsPerConnectionValidation) {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1559,7 +1559,7 @@ TEST_F(HostImplTest, HealthStatus) {
   host->setEdsHealthStatus(Host::HealthStatus::DRAINING);
   EXPECT_EQ(Host::HealthStatus::DRAINING, host->healthStatus());
   EXPECT_EQ(Host::HealthStatus::DRAINING, host->edsHealthStatus());
-
+  EXPECT_EQ(Host::Health::Unhealthy, host->coarseHealth());
   // Old EDS flags should be cleared and new flag will be set.
   EXPECT_TRUE(host->healthFlagGet(Host::HealthFlag::DRAINING_EDS_HEALTH));
 
@@ -1586,7 +1586,7 @@ TEST_F(HostImplTest, HealthStatus) {
   host->healthFlagClear(Host::HealthFlag::FAILED_OUTLIER_CHECK);
   EXPECT_EQ(Host::HealthStatus::DRAINING, host->healthStatus());
   EXPECT_EQ(Host::HealthStatus::DRAINING, host->edsHealthStatus());
-//  EXPECT_EQ(Host::Health::Unhealthy, host->coarseHealth());
+  EXPECT_EQ(Host::Health::Unhealthy, host->coarseHealth());
 
   // If the unhealthy EDS is removed, the active degraded flag is used.
   host->setEdsHealthStatus(Host::HealthStatus::HEALTHY);


### PR DESCRIPTION
Commit Message: upstream: exclude draining hosts from eds
Additional Description: 
Exclude hosts set to `DRAINING` state via EDS from load balancing, panic routing threshold calculation.
Risk Level: low
Testing: unit tests
Docs Changes: yes
Release Notes: no